### PR TITLE
new release for readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sudo-gcp"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 readme = "README.md"


### PR DESCRIPTION
crates.io considers the README.md immutable per version. So we need a new release to fix the README. :) 